### PR TITLE
Integration tests for validator startup

### DIFF
--- a/tests/integration/test_validator_startup.py
+++ b/tests/integration/test_validator_startup.py
@@ -1,0 +1,229 @@
+import unittest
+
+import urllib2
+import time
+
+from ledger.transaction.endpoint_registry import EndpointRegistryTransaction
+
+from txnintegration.exceptions import ValidatorManagerException, ExitError
+from txnintegration.integer_key_client import IntegerKeyClient
+from txnintegration.utils import generate_private_key, Progress, TimeOut
+from txnintegration.validator_network_manager import ValidatorNetworkManager
+from txnintegration.validator_network_manager import defaultValidatorConfig
+from txnserver.endpoint_registry_client import EndpointRegistryClient
+from txnserver.ledger_web_client import LedgerWebClient
+
+
+class TestBasicStartup(unittest.TestCase):
+
+    def setUp(self):
+        self.vnm = ValidatorNetworkManager(cfg=defaultValidatorConfig.copy())
+
+    def _verify_equality_of_block_lists(self, webclients):
+        block_lists = []
+        for ledger_client in webclients:
+            block_list = []
+            node_ids = set(ledger_client.get_store(
+                txntype=EndpointRegistryTransaction))
+            for b in ledger_client.get_block_list():
+                tids_from_blocks = ledger_client.get_block(
+                    blockid=b, field='TransactionIDs')
+                node_ids_from_blocks = []
+                for tid in tids_from_blocks:
+                    node = ledger_client.\
+                        get_transaction(tid, 'Update').get('NodeIdentifier')
+                    node_ids_from_blocks.append(node)
+
+                if len(node_ids.intersection(node_ids_from_blocks)) > 0:
+                    block_list.append(b)
+            block_lists.append(block_list)
+        self.assertEqual(len(max(block_lists, key=len)),
+                         len(min(block_lists, key=len)),
+                         "The length of the EndpointRegistry "
+                         "block lists are the same for all validators")
+        zeroth_block_list = block_lists[0]
+        for bl in block_lists[1:]:
+            self.assertEqual(zeroth_block_list, bl,
+                             "The block lists are the same for each validator")
+
+    def _verify_orderly_transactions(self, webclients, node_identifiers):
+        for ledger_client in webclients:
+            node_ids = []
+            for b in ledger_client.get_block_list():
+                if not ledger_client.get_block(blockid=b,
+                                               field='BlockNum') == 0L:
+                    # the genesis block has no transactions
+                    tids_from_blocks = ledger_client.get_block(
+                        blockid=b, field='TransactionIDs')
+                    self.assertEqual(len(tids_from_blocks), 1,
+                                     "One transaction per block")
+                    node = ledger_client.get_transaction(
+                        tids_from_blocks[0],
+                        'Update').get('NodeIdentifier')
+                    node_ids.append(node)
+            node_ids.reverse()
+            self.assertEqual(len(node_identifiers), len(node_ids),
+                             "The node list lengths are the same")
+            self.assertEqual(node_ids, node_identifiers,
+                             "The node lists are the same")
+
+    def test_basic_startup(self):
+        try:
+            self.vnm.launch_network(count=15, others_daemon=True)
+
+            validator_urls = self.vnm.urls()
+            # IntegerKeyClient is only needed to send one more transaction
+            # so n-1=number of EndpointRegistryTransactions
+            integer_key_clients = [
+                IntegerKeyClient(baseurl=u,
+                                 keystring=generate_private_key())
+                for u in validator_urls
+            ]
+            ledger_web_clients = [
+                LedgerWebClient(url=u) for u in validator_urls]
+            for int_key_client in integer_key_clients:
+                int_key_client.set(key=str(1), value=20)
+            self._verify_equality_of_block_lists(ledger_web_clients)
+
+        finally:
+            self.vnm.shutdown()
+            self.vnm.create_result_archive('TestDaemonStartup.tar.gz')
+
+    def test_join_after_delay_start(self):
+        delayed_validator = None
+        validator_urls = []
+        try:
+            self.vnm.launch_network(count=5)
+            validator_urls = self.vnm.urls()
+
+            delayed_validator = self.vnm.launch_node(delay=True)
+            time.sleep(5)
+
+            command_url = delayed_validator.Url + '/command'
+            request = urllib2.Request(
+                url=command_url,
+                headers={'Content-Type': 'application/json'})
+            response = urllib2.urlopen(request,
+                                       data='{"action": "start"}')
+            response.close()
+            self.assertEqual(response.code, 200,
+                             "Successful post to delayed validator")
+
+            validator_urls.append(delayed_validator.Url)
+            ledger_web_clients = [
+                LedgerWebClient(url=u) for u in validator_urls
+            ]
+
+            with Progress("Waiting for registration of 1 validator") as p:
+                url = validator_urls[0]
+                to = TimeOut(60)
+                while not delayed_validator.is_registered(url):
+                    if to():
+                        raise ExitError(
+                            "{} delayed validator failed to register "
+                            "within {}S.".format(
+                                1, to.WaitTime))
+                    p.step()
+                    time.sleep(1)
+                    try:
+                        delayed_validator.check_error()
+                    except ValidatorManagerException as vme:
+                        delayed_validator.dump_log()
+                        delayed_validator.dump_stderr()
+                        raise ExitError(str(vme))
+            integer_key_clients = [
+                IntegerKeyClient(baseurl=u,
+                                 keystring=generate_private_key())
+                for u in validator_urls
+            ]
+
+            for int_key_client in integer_key_clients:
+                int_key_client.set(key=str(1), value=20)
+
+            self._verify_equality_of_block_lists(ledger_web_clients)
+
+        finally:
+            self.vnm.shutdown()
+            if delayed_validator is not None and \
+                    validator_urls is not [] and \
+                    delayed_validator.Url not in validator_urls:
+                delayed_validator.shutdown()
+            self.vnm.create_result_archive("TestDelayedStart.tar.gz")
+
+    def test_initial_connectivity_n_minus_1(self):
+        try:
+            self.vnm.ValidatorConfig['LedgerURL'] = "**none**"
+            self.vnm.ValidatorConfig['Restore'] = False
+            validator = self.vnm.launch_node(genesis=True)
+            validators = [validator]
+            with Progress("Launching validator network") as p:
+                self.vnm.ValidatorConfig['LedgerURL'] = validator.Url
+                self.vnm.ValidatorConfig['Restore'] = False
+                node_identifiers = [validator.Address]
+                for i in range(1, 10):
+                    self.vnm.ValidatorConfig['InitialConnectivity'] = i
+                    v = self.vnm.launch_node(genesis=False, daemon=False)
+                    validators.append(v)
+                    node_identifiers.append(v.Address)
+                    p.step()
+                    # for each new validator we will wait_for_registration
+                    self.vnm.wait_for_registration(validators, validator)
+            self.vnm.wait_for_registration(validators, validator)
+            validator_urls = self.vnm.urls()
+            ledger_web_clients = [
+                LedgerWebClient(url=u) for u in validator_urls
+            ]
+            integer_key_clients = [
+                IntegerKeyClient(baseurl=u,
+                                 keystring=generate_private_key())
+                for u in validator_urls
+            ]
+
+            for int_key_client in integer_key_clients:
+                int_key_client.set(key=str(1), value=20)
+
+            self._verify_equality_of_block_lists(ledger_web_clients)
+            self._verify_orderly_transactions(ledger_web_clients,
+                                              node_identifiers)
+        finally:
+            self.vnm.shutdown()
+            self.vnm.create_result_archive(
+                'TestOrderlyInitialConnectivity.tar.gz')
+
+    def test_adding_node_with_nodelist(self):
+        try:
+            validators = self.vnm.launch_network(5)
+            validator_urls = self.vnm.urls()
+            endpoint_client = EndpointRegistryClient(validator_urls[0])
+            nodes = []
+            for epl in endpoint_client.get_endpoint_list():
+                node = {}
+                node['Host'] = epl['Host']
+                node['Port'] = epl['Port']
+                node['Identifier'] = epl['NodeIdentifier']
+                node['ShortName'] = epl['Name']
+                nodes.append(node)
+            peers = [nodes[0]['ShortName'], nodes[2]['ShortName'],
+                     'validator-x']
+            self.vnm.ValidatorConfig['Nodes'] = nodes
+            self.vnm.ValidatorConfig['Peers'] = peers
+            v = self.vnm.launch_node()
+            validator_urls.append(v.Url)
+
+            self.vnm.wait_for_registration([v], validators[0])
+            ledger_web_clients = [
+                LedgerWebClient(url=u) for u in validator_urls
+            ]
+            integer_key_clients = [
+                IntegerKeyClient(baseurl=u,
+                                 keystring=generate_private_key())
+                for u in validator_urls
+            ]
+
+            for int_key_client in integer_key_clients:
+                int_key_client.set(key=str(1), value=20)
+            self._verify_equality_of_block_lists(ledger_web_clients)
+
+        finally:
+            self.vnm.shutdown()
+            self.vnm.create_result_archive('TestNodeList.tar.gz')

--- a/tests/integration/test_validator_startup.py
+++ b/tests/integration/test_validator_startup.py
@@ -1,7 +1,9 @@
 import unittest
 
-import urllib2
+import os
 import time
+import urllib2
+
 
 from ledger.transaction.endpoint_registry import EndpointRegistryTransaction
 
@@ -17,6 +19,7 @@ from txnserver.ledger_web_client import LedgerWebClient
 class TestBasicStartup(unittest.TestCase):
 
     def setUp(self):
+        self.number_of_daemons = int(os.environ.get("NUMBER_OF_DAEMONS", 5))
         self.vnm = ValidatorNetworkManager(cfg=defaultValidatorConfig.copy())
 
     def _verify_equality_of_block_lists(self, webclients):
@@ -69,7 +72,9 @@ class TestBasicStartup(unittest.TestCase):
 
     def test_basic_startup(self):
         try:
-            self.vnm.launch_network(count=15, others_daemon=True)
+
+            self.vnm.launch_network(count=self.number_of_daemons,
+                                    others_daemon=True)
 
             validator_urls = self.vnm.urls()
             # IntegerKeyClient is only needed to send one more transaction
@@ -93,7 +98,7 @@ class TestBasicStartup(unittest.TestCase):
         delayed_validator = None
         validator_urls = []
         try:
-            self.vnm.launch_network(count=5)
+            self.vnm.launch_network(5)
             validator_urls = self.vnm.urls()
 
             delayed_validator = self.vnm.launch_node(delay=True)
@@ -160,7 +165,7 @@ class TestBasicStartup(unittest.TestCase):
                 self.vnm.ValidatorConfig['LedgerURL'] = validator.Url
                 self.vnm.ValidatorConfig['Restore'] = False
                 node_identifiers = [validator.Address]
-                for i in range(1, 10):
+                for i in range(1, 5):
                     self.vnm.ValidatorConfig['InitialConnectivity'] = i
                     v = self.vnm.launch_node(genesis=False, daemon=False)
                     validators.append(v)

--- a/tests/integration/test_validator_startup.py
+++ b/tests/integration/test_validator_startup.py
@@ -16,6 +16,12 @@ from txnserver.endpoint_registry_client import EndpointRegistryClient
 from txnserver.ledger_web_client import LedgerWebClient
 
 
+ENABLE_STARTUP_TESTS = False
+if os.environ.get('ENABLE_STARTUP_TESTS') == '1':
+    ENABLE_STARTUP_TESTS = True
+
+
+@unittest.skipUnless(ENABLE_STARTUP_TESTS, "Startup Tests")
 class TestBasicStartup(unittest.TestCase):
 
     def setUp(self):
@@ -171,8 +177,6 @@ class TestBasicStartup(unittest.TestCase):
                     validators.append(v)
                     node_identifiers.append(v.Address)
                     p.step()
-                    # for each new validator we will wait_for_registration
-                    self.vnm.wait_for_registration(validators, validator)
             self.vnm.wait_for_registration(validators, validator)
             validator_urls = self.vnm.urls()
             ledger_web_clients = [

--- a/txnintegration/validator_manager.py
+++ b/txnintegration/validator_manager.py
@@ -53,7 +53,7 @@ class ValidatorManager(object):
         self.Key = generate_private_key()
         self.Address = get_address_from_private_key_wif(self.Key)
 
-    def launch(self, launch=True):
+    def launch(self, launch=True, genesis=False, daemon=False, delay=False):
         self.Url = "http://{}:{}".format(self.config['Host'],
                                          self.config['HttpPort'])
         self.config['LogFile'] = os.path.join(self.dataDir,
@@ -85,6 +85,15 @@ class ValidatorManager(object):
             "--config",
             configFileName
         ]
+
+        if genesis:
+            args.append("--genesis")
+
+        if daemon:
+            args.append("--daemon")
+
+        if delay:
+            args.append("--delay-start")
 
         # redirect stdout and stderror
         self.stdoutFile = os.path.join(self.dataDir,

--- a/txnserver/validator.py
+++ b/txnserver/validator.py
@@ -129,7 +129,6 @@ class Validator(object):
             nd = node.Node(address=addr,
                            identifier=nodedata["Identifier"],
                            name=nodedata["ShortName"])
-            nd.disable()
             self.NodeMap[nodedata["ShortName"]] = nd
 
     def initialize_ledger_object(self):


### PR DESCRIPTION
Four tests: test with a genesis validator and then 15 daemon validators join the network, test with a genesis validator and then 4 others join the network, and then a delayed-start validator joins, test with nodes and peers specified in the config.

The nodes hit some leftover code, nd.disable, that I removed to make the test run.

The ValidatorManager, and ValidatorNetworkManager are slightly modified to allow daemon, genesis, and delay parameters.